### PR TITLE
[feature request] adding `{percent_precise}` style key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,8 @@
 //! * `len`: renders the amount of work to be done as an integer
 //! * `human_len`: renders the total length of the bar as an integer, with commas as the thousands
 //! separator.
-//! * `percent`: renders the current position of the bar as a percentage of the total length.
+//! * `percent`: renders the current position of the bar as a percentage of the total length (as an integer).
+//! * `percent_precise`: renders the current position of the bar as a percentage of the total length (with 3 fraction digits).
 //! * `bytes`: renders the current position of the bar as bytes (alias of `binary_bytes`).
 //! * `total_bytes`: renders the total length of the bar as bytes (alias of `binary_total_bytes`).
 //! * `decimal_bytes`: renders the current position of the bar as bytes using

--- a/src/style.rs
+++ b/src/style.rs
@@ -282,6 +282,9 @@ impl ProgressStyle {
                             "percent" => buf
                                 .write_fmt(format_args!("{:.*}", 0, state.fraction() * 100f32))
                                 .unwrap(),
+                            "percent_precise" => buf
+                                .write_fmt(format_args!("{:.*}", 3, state.fraction() * 100f32))
+                                .unwrap(),
                             "bytes" => buf.write_fmt(format_args!("{}", HumanBytes(pos))).unwrap(),
                             "total_bytes" => {
                                 buf.write_fmt(format_args!("{}", HumanBytes(len))).unwrap();

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -95,6 +95,39 @@ fn progress_bar_percent_with_no_length() {
 }
 
 #[test]
+fn progress_bar_percent_precise_with_no_length() {
+    let in_mem = InMemoryTerm::new(10, 80);
+    let pb = ProgressBar::with_draw_target(
+        None,
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    )
+    .with_style(ProgressStyle::with_template("{wide_bar} {percent_precise}%").unwrap());
+
+    assert_eq!(in_mem.contents(), String::new());
+
+    pb.tick();
+
+    assert_eq!(
+        in_mem.contents(),
+        "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0.000%"
+    );
+
+    pb.set_length(10);
+
+    pb.inc(1);
+    assert_eq!(
+        in_mem.contents(),
+        "███████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 10.000%"
+    );
+
+    pb.finish();
+    assert_eq!(
+        in_mem.contents(),
+        "███████████████████████████████████████████████████████████████████████ 100.000%"
+    );
+}
+
+#[test]
 fn multi_progress_single_bar_and_leave() {
     let in_mem = InMemoryTerm::new(10, 80);
     let mp =


### PR DESCRIPTION
The existing `{percent}` is rendered as an integer, which means it is not very useful for large data sets, as it rarely changes.

I suggest adding a new `{percent_precise}` (a non-breaking change?) that would render it with additional precision. For example, 3 fraction digits, as demonstrated by the test added here.

An earlier proposal to add precision to variables was rejected (#552), and AFAIK, there is no way to customize this without taking over rendering.

I think it would work well with existing variables like `elapsed_precise`, `eta_precise`.

Thanks for considering!